### PR TITLE
close file after reading it

### DIFF
--- a/octoprint_SlicerSettingsParser/__init__.py
+++ b/octoprint_SlicerSettingsParser/__init__.py
@@ -86,6 +86,7 @@ class SlicerSettingsParserPlugin(
 				slicer_settings[key] = val
 
 				break
+		file.close()
 
 		self._storage_interface.set_additional_metadata(path, "slicer_settings", slicer_settings, overwrite=True)
 


### PR DESCRIPTION
> Python automatically closes a file when the reference object of a file is reassigned to another file. It is a good practice to use the close() method to close a file.